### PR TITLE
Fixed 9-Slice setColor function

### DIFF
--- a/widgetLibrary/widget_button.lua
+++ b/widgetLibrary/widget_button.lua
@@ -1104,7 +1104,7 @@ local function createUsing9Slice( button, options )
 	function button:setFillColor( ... )		
 		for i = self._view.numChildren, 1, -1 do
 			local child = self._view[i]
-			if child.setFillColor and "function" == type( child.setFillColor ) then
+			if child.setFillColor and "function" == type( child.setFillColor ) and not child._isLabel then
 				child:setFillColor( ... )
 			end
 		end


### PR DESCRIPTION
Function `setColor`would not change color on 9-Slice buttons, since it iterated over the buttons children, which would only be `_view`. Instead, we iterate on `self._view`s children, which contain all the slices.
