### PR TITLE
BugFix of Runtime error ?:0: attempt to index field '_view' (a nil value) on swipe

### DIFF
--- a/widgetLibrary/widget_tableview.lua
+++ b/widgetLibrary/widget_tableview.lua
@@ -490,7 +490,7 @@ local function createTableView( tableView, options )
 					if self._targetRow._separator then
 						self._targetRow._separator.isVisible = true
 					end
-					if view._rows[ self._targetRow.index - 1 ] then
+					if view._rows[ self._targetRow.index - 1 ] and view._rows[ self._targetRow.index - 1 ]._view then
 						if view._rows[ self._targetRow.index - 1 ]._view._separator then
 							view._rows[ self._targetRow.index - 1 ]._view._separator.isVisible = true
 						end
@@ -600,7 +600,7 @@ local function createTableView( tableView, options )
 						if self._targetRow._separator then
 							self._targetRow._separator.isVisible = false
 						end
-						if view._rows[ self._targetRow.index - 1 ] then
+						if view._rows[ self._targetRow.index - 1 ] and view._rows[ self._targetRow.index - 1 ]._view then
 							if view._rows[ self._targetRow.index - 1 ]._view._separator then
 								view._rows[ self._targetRow.index - 1 ]._view._separator.isVisible = false
 							end


### PR DESCRIPTION
Those additional checks prevent the Runtime error when among others you have a single long row (rowHeight > 200) almost all offscreen and you try to swipe on it. Virtualisation removes the "_targetRow.index - 1" so there is no _separator to hide.