### PR TITLE
Make runnable on current Corona SDK (Storyboard -> Composer)

### DIFF
--- a/button.lua
+++ b/button.lua
@@ -2,8 +2,8 @@
 -- File: newButton unit test.
 
 local widget = require( "widget" )
-local storyboard = require( "storyboard" )
-local scene = storyboard.newScene()
+local composer = require( "composer" )
+local scene = composer.newScene()
 
 local isGraphicsV1 = ( 1 == display.getDefault( "graphicsCompatibility" ) )
 
@@ -55,7 +55,7 @@ function scene:createScene( event )
 		labelAlign = "center",
 	    width = 200, height = backButtonSize,
 	    cornerRadius = 8,
-	    onRelease = function() storyboard.gotoScene( "unitTestListing" ) end;
+	    onRelease = function() composer.gotoScene( "unitTestListing" ) end;
 	}
 	returnToListing.x = display.contentCenterX
 	group:insert( returnToListing )
@@ -314,10 +314,10 @@ function scene:didExitScene( event )
 		testTimer = nil
 	end
 	
-	storyboard.removeAll()
+	composer.removeAll()
 end
 
-scene:addEventListener( "createScene", scene )
-scene:addEventListener( "didExitScene", scene )
+scene:addEventListener( "create", function(event) scene:createScene(event) end )
+scene:addEventListener( "hide", function(event) print("hide"); if event.phase == 'did' then scene:didExitScene(event) end end )
 
 return scene

--- a/main.lua
+++ b/main.lua
@@ -44,7 +44,6 @@ io.output():setvbuf( "no" )
 -- Hide the status bar
 display.setStatusBar( display.HiddenStatusBar )
 
-local storyboard = require( "storyboard" )
-storyboard.gotoScene( "unitTestListing" )
-
---storyboard.gotoScene( "tableView" )
+local composer = require( "composer" )
+composer.gotoScene( "unitTestListing" )
+--composer.gotoScene( "tableView" )

--- a/picker.lua
+++ b/picker.lua
@@ -2,8 +2,8 @@
 -- File: newPickerWheel unit test.
 
 local widget = require( "widget" )
-local storyboard = require( "storyboard" )
-local scene = storyboard.newScene()
+local composer = require( "composer" )
+local scene = composer.newScene()
 
 local isGraphicsV1 = ( 1 == display.getDefault( "graphicsCompatibility" ) )
 
@@ -49,7 +49,7 @@ function scene:createScene( event )
 	    top = backButtonPosition,
 	    label = "Exit",
 	    width = 200, height = backButtonSize,
-	    onRelease = function() storyboard.gotoScene( "unitTestListing" ) end;
+	    onRelease = function() composer.gotoScene( "unitTestListing" ) end;
 	}
 	returnToListing.x = display.contentCenterX
 	group:insert( returnToListing )
@@ -145,10 +145,10 @@ function scene:didExitScene( event )
 		testTimer = nil
 	end
 	
-	storyboard.removeAll()
+	composer.removeAll()
 end
 
-scene:addEventListener( "createScene", scene )
-scene:addEventListener( "didExitScene", scene )
+scene:addEventListener( "create", function(event) scene:createScene(event) end )
+scene:addEventListener( "hide", function(event) print("hide"); if event.phase == 'did' then scene:didExitScene(event) end end )
 
 return scene

--- a/progressView.lua
+++ b/progressView.lua
@@ -2,8 +2,8 @@
 -- File: newProgressView unit test.
 
 local widget = require( "widget" )
-local storyboard = require( "storyboard" )
-local scene = storyboard.newScene()
+local composer = require( "composer" )
+local scene = composer.newScene()
 
 local isGraphicsV1 = ( 1 == display.getDefault( "graphicsCompatibility" ) )
 
@@ -53,7 +53,7 @@ function scene:createScene( event )
 	    label = "Exit",
 	    width = 200, height = backButtonSize,
 	    cornerRadius = 8,
-	    onRelease = function() storyboard.gotoScene( "unitTestListing" ) end;
+	    onRelease = function() composer.gotoScene( "unitTestListing" ) end;
 	}
 	returnToListing.x = display.contentCenterX
 	group:insert( returnToListing )
@@ -124,10 +124,10 @@ function scene:didExitScene( event )
 		testTimer = nil
 	end
 	
-	storyboard.removeAll()
+	composer.removeAll()
 end
 
-scene:addEventListener( "createScene", scene )
-scene:addEventListener( "didExitScene", scene )
+scene:addEventListener( "create", function(event) scene:createScene(event) end )
+scene:addEventListener( "hide", function(event) print("hide"); if event.phase == 'did' then scene:didExitScene(event) end end )
 
 return scene

--- a/scrollView.lua
+++ b/scrollView.lua
@@ -2,8 +2,8 @@
 -- File: newScrollView unit test.
 
 local widget = require( "widget" )
-local storyboard = require( "storyboard" )
-local scene = storyboard.newScene()
+local composer = require( "composer" )
+local scene = composer.newScene()
 
 --Forward reference for test function timer
 local testTimer = nil
@@ -55,7 +55,7 @@ function scene:createScene( event )
 		labelAlign = "center",
 	    width = 200, height = backButtonSize,
 	    cornerRadius = 8,
-	    onRelease = function() storyboard.gotoScene( "unitTestListing" ) end;
+	    onRelease = function() composer.gotoScene( "unitTestListing" ) end;
 	}
 	returnToListing.x = display.contentCenterX
 	group:insert( returnToListing )
@@ -598,10 +598,10 @@ function scene:didExitScene( event )
 		testTimer = nil
 	end
 	
-	storyboard.removeAll()
+	composer.removeAll()
 end
 
-scene:addEventListener( "createScene", scene )
-scene:addEventListener( "didExitScene", scene )	
+scene:addEventListener( "create", function(event) scene:createScene(event) end )
+scene:addEventListener( "hide", function(event) print("hide"); if event.phase == 'did' then scene:didExitScene(event) end end )	
 
 return scene

--- a/searchField.lua
+++ b/searchField.lua
@@ -2,8 +2,8 @@
 -- File: newSearchField unit test.
 
 local widget = require( "widget" )
-local storyboard = require( "storyboard" )
-local scene = storyboard.newScene()
+local composer = require( "composer" )
+local scene = composer.newScene()
 
 local USE_ANDROID_THEME = false
 local USE_IOS7_THEME = true
@@ -68,7 +68,7 @@ function scene:createScene( event )
 	    label = "Exit",
 	    width = 200, height = backButtonSize,
 	    cornerRadius = 8,
-	    onRelease = function() storyboard.gotoScene( "unitTestListing" ) end;
+	    onRelease = function() composer.gotoScene( "unitTestListing" ) end;
 	}
 	returnToListing.x = display.contentCenterX
 	group:insert( returnToListing )
@@ -128,10 +128,10 @@ function scene:didExitScene( event )
 		testTimer = nil
 	end
 	
-	storyboard.removeAll()
+	composer.removeAll()
 end
 
-scene:addEventListener( "createScene", scene )
-scene:addEventListener( "didExitScene", scene )
+scene:addEventListener( "create", function(event) scene:createScene(event) end )
+scene:addEventListener( "hide", function(event) print("hide"); if event.phase == 'did' then scene:didExitScene(event) end end )
 
 return scene

--- a/segmentedControl.lua
+++ b/segmentedControl.lua
@@ -2,8 +2,8 @@
 -- File: newSegmentedControl unit test.
 
 local widget = require( "widget" )
-local storyboard = require( "storyboard" )
-local scene = storyboard.newScene()
+local composer = require( "composer" )
+local scene = composer.newScene()
 
 local isGraphicsV1 = ( 1 == display.getDefault( "graphicsCompatibility" ) )
 
@@ -53,7 +53,7 @@ function scene:createScene( event )
 	    label = "Exit",
 	    width = 200, height = backButtonSize,
 	    cornerRadius = 8,
-	    onRelease = function() storyboard.gotoScene( "unitTestListing" ) end;
+	    onRelease = function() composer.gotoScene( "unitTestListing" ) end;
 	}
 	returnToListing.x = display.contentCenterX
 	group:insert( returnToListing )
@@ -120,10 +120,10 @@ function scene:didExitScene( event )
 		testTimer = nil
 	end
 	
-	storyboard.removeAll()
+	composer.removeAll()
 end
 
-scene:addEventListener( "createScene", scene )
-scene:addEventListener( "didExitScene", scene )
+scene:addEventListener( "create", function(event) scene:createScene(event) end )
+scene:addEventListener( "hide", function(event) print("hide"); if event.phase == 'did' then scene:didExitScene(event) end end )
 
 return scene

--- a/slider.lua
+++ b/slider.lua
@@ -2,8 +2,8 @@
 -- File: newSlider unit test.
 
 local widget = require( "widget" )
-local storyboard = require( "storyboard" )
-local scene = storyboard.newScene()
+local composer = require( "composer" )
+local scene = composer.newScene()
 
 local isGraphicsV1 = ( 1 == display.getDefault( "graphicsCompatibility" ) )
 
@@ -54,7 +54,7 @@ function scene:createScene( event )
 	    label = "Exit",
 	    width = 200, height = backButtonSize,
 	    cornerRadius = 8,
-	    onRelease = function() storyboard.gotoScene( "unitTestListing" ) end;
+	    onRelease = function() composer.gotoScene( "unitTestListing" ) end;
 	}
 	returnToListing.x = display.contentCenterX
 	group:insert( returnToListing )
@@ -130,10 +130,10 @@ function scene:didExitScene( event )
 		testTimer = nil
 	end
 	
-	storyboard.removeAll()
+	composer.removeAll()
 end
 
-scene:addEventListener( "createScene", scene )
-scene:addEventListener( "didExitScene", scene )
+scene:addEventListener( "create", function(event) scene:createScene(event) end )
+scene:addEventListener( "hide", function(event) print("hide"); if event.phase == 'did' then scene:didExitScene(event) end end )
 
 return scene

--- a/spinner.lua
+++ b/spinner.lua
@@ -2,8 +2,8 @@
 -- File: newSpinner unit test.
 
 local widget = require( "widget" )
-local storyboard = require( "storyboard" )
-local scene = storyboard.newScene()
+local composer = require( "composer" )
+local scene = composer.newScene()
 
 local isGraphicsV1 = ( 1 == display.getDefault( "graphicsCompatibility" ) )
 
@@ -55,7 +55,7 @@ function scene:createScene( event )
 	    label = "Exit",
 	    width = 200, height = backButtonSize,
 	    cornerRadius = 8,
-	    onRelease = function() storyboard.gotoScene( "unitTestListing" ) end;
+	    onRelease = function() composer.gotoScene( "unitTestListing" ) end;
 	}
 	returnToListing.x = display.contentCenterX
 	group:insert( returnToListing )
@@ -204,7 +204,7 @@ function scene:exitScene( event )
 		testTimer = nil
 	end
 	
-	--storyboard.purgeAll()
+	--composer.purgeAll()
 end
 
 function scene:didExitScene( event )
@@ -214,10 +214,10 @@ function scene:didExitScene( event )
 		testTimer = nil
 	end
 	
-	storyboard.removeAll()
+	composer.removeAll()
 end
 
-scene:addEventListener( "createScene", scene )
-scene:addEventListener( "didExitScene", scene )
+scene:addEventListener( "create", function(event) scene:createScene(event) end )
+scene:addEventListener( "hide", function(event) print("hide"); if event.phase == 'did' then scene:didExitScene(event) end end )
 
 return scene

--- a/stepper.lua
+++ b/stepper.lua
@@ -2,8 +2,8 @@
 -- File: newStepper unit test.
 
 local widget = require( "widget" )
-local storyboard = require( "storyboard" )
-local scene = storyboard.newScene()
+local composer = require( "composer" )
+local scene = composer.newScene()
 
 local USE_IOS7_THEME = true
 local isGraphicsV1 = ( 1 == display.getDefault( "graphicsCompatibility" ) )
@@ -55,7 +55,7 @@ function scene:createScene( event )
 	    label = "Exit",
 	    width = 200, height = backButtonSize,
 	    cornerRadius = 8,
-	    onRelease = function() storyboard.gotoScene( "unitTestListing" ) end;
+	    onRelease = function() composer.gotoScene( "unitTestListing" ) end;
 	}
 	group:insert( returnToListing )
 	
@@ -133,10 +133,10 @@ function scene:didExitScene( event )
 		testTimer = nil
 	end
 	
-	storyboard.removeAll()
+	composer.removeAll()
 end
 
-scene:addEventListener( "createScene", scene )
-scene:addEventListener( "didExitScene", scene )
+scene:addEventListener( "create", function(event) scene:createScene(event) end )
+scene:addEventListener( "hide", function(event) print("hide"); if event.phase == 'did' then scene:didExitScene(event) end end )
 
 return scene

--- a/switch.lua
+++ b/switch.lua
@@ -2,8 +2,8 @@
 -- File: newSwitch unit test.
 
 local widget = require( "widget" )
-local storyboard = require( "storyboard" )
-local scene = storyboard.newScene()
+local composer = require( "composer" )
+local scene = composer.newScene()
 
 local isGraphicsV1 = ( 1 == display.getDefault( "graphicsCompatibility" ) )
 
@@ -55,7 +55,7 @@ function scene:createScene( event )
 	    label = "Exit",
 	    width = 200, height = backButtonSize,
 	    cornerRadius = 8,
-	    onRelease = function() storyboard.gotoScene( "unitTestListing" ) end;
+	    onRelease = function() composer.gotoScene( "unitTestListing" ) end;
 	}
 	returnToListing.x = display.contentCenterX
 	group:insert( returnToListing )
@@ -274,10 +274,10 @@ function scene:didExitScene( event )
 		testTimer = nil
 	end
 	
-	storyboard.removeAll()
+	composer.removeAll()
 end
 
-scene:addEventListener( "createScene", scene )
-scene:addEventListener( "didExitScene", scene )
+scene:addEventListener( "create", function(event) scene:createScene(event) end )
+scene:addEventListener( "hide", function(event) print("hide"); if event.phase == 'did' then scene:didExitScene(event) end end )
 
 return scene

--- a/tabBar.lua
+++ b/tabBar.lua
@@ -2,8 +2,8 @@
 -- File: newTabBar unit test.
 
 local widget = require( "widget" )
-local storyboard = require( "storyboard" )
-local scene = storyboard.newScene()
+local composer = require( "composer" )
+local scene = composer.newScene()
 
 local USE_IOS7_THEME = false
 local isGraphicsV1 = ( 1 == display.getDefault( "graphicsCompatibility" ) )
@@ -55,7 +55,7 @@ function scene:createScene( event )
 	    label = "Exit",
 	    width = 200, height = backButtonSize,
 	    cornerRadius = 8,
-	    onRelease = function() storyboard.gotoScene( "unitTestListing" ) end;
+	    onRelease = function() composer.gotoScene( "unitTestListing" ) end;
 	}
 	returnToListing.x = display.contentCenterX
 	group:insert( returnToListing )
@@ -288,10 +288,10 @@ function scene:didExitScene( event )
 		testTimer = nil
 	end
 	
-	storyboard.removeAll()
+	composer.removeAll()
 end
 
-scene:addEventListener( "createScene", scene )
-scene:addEventListener( "didExitScene", scene )
+scene:addEventListener( "create", function(event) scene:createScene(event) end )
+scene:addEventListener( "hide", function(event) print("hide"); if event.phase == 'did' then scene:didExitScene(event) end end )
 
 return scene

--- a/tableView.lua
+++ b/tableView.lua
@@ -2,8 +2,8 @@
 -- File: newTableView unit test.
 
 local widget = require( "widget" )
-local storyboard = require( "storyboard" )
-local scene = storyboard.newScene()
+local composer = require( "composer" )
+local scene = composer.newScene()
 
 --Forward reference for test function timer
 local testTimer = nil
@@ -67,7 +67,7 @@ function scene:createScene( event )
 		labelAlign = "center",
 	    width = 200, height = backButtonSize,
 	    cornerRadius = 8,
-	    onRelease = function() storyboard.gotoScene( "unitTestListing" ) end;
+	    onRelease = function() composer.gotoScene( "unitTestListing" ) end;
 	}
 	returnToListing.x = display.contentCenterX
 	group:insert( returnToListing )
@@ -349,10 +349,10 @@ function scene:didExitScene( event )
 		testTimer = nil
 	end
 	
-	storyboard.removeAll()
+	composer.removeAll()
 end
 
-scene:addEventListener( "createScene", scene )
-scene:addEventListener( "didExitScene", scene )
+scene:addEventListener( "create", function(event) scene:createScene(event) end )
+scene:addEventListener( "hide", function(event) print("hide"); if event.phase == 'did' then scene:didExitScene(event) end end )
 
 return scene

--- a/templates/unit_test_template.lua
+++ b/templates/unit_test_template.lua
@@ -20,8 +20,8 @@ package.preload.widget = nil
 -------------------------------------------------------------------------------------------------
 
 local widget = require( "widget" )
-local storyboard = require( "storyboard" )
-local scene = storyboard.newScene()
+local composer = require( "composer" )
+local scene = composer.newScene()
 
 function scene:createScene( event )
 	local group = self.view
@@ -38,7 +38,7 @@ function scene:createScene( event )
 	    label = "Return To Menu",
 	    width = 200, height = 52,
 	    cornerRadius = 8,
-	    onRelease = function() storyboard.gotoScene( "unitTestListing" ) end;
+	    onRelease = function() composer.gotoScene( "unitTestListing" ) end;
 	}
 	group:insert( returnToListing )
 	
@@ -72,10 +72,10 @@ function scene:createScene( event )
 end
 
 function scene:exitScene( event )
-	storyboard.purgeAll()
+	composer.purgeAll()
 end
 
-scene:addEventListener( "createScene", scene )
+scene:addEventListener( "create", function(event) scene:createScene(event) end )
 scene:addEventListener( "exitScene", scene )
 
 return scene

--- a/unitTestListing.lua
+++ b/unitTestListing.lua
@@ -2,8 +2,8 @@
 
 local widget = require( "widget" )
 
-local storyboard = require( "storyboard" )
-local scene = storyboard.newScene()
+local composer = require( "composer" )
+local scene = composer.newScene()
 
 local USE_IOS_THEME = false
 local USE_IOS7_THEME = false
@@ -101,7 +101,7 @@ function scene:createScene( event )
 		
 		if "ended" == phase then
 			local targetScene = event.target.id
-			storyboard.gotoScene( targetScene )
+			composer.gotoScene( targetScene )
 		end
 		
 		return true
@@ -271,10 +271,10 @@ function scene:createScene( event )
 end
 
 function scene:didExitScene( event )
-	storyboard.removeAll()
+	composer.removeAll()
 end
 
-scene:addEventListener( "createScene", scene )
-scene:addEventListener( "didExitScene", scene )
+scene:addEventListener( "create", function(event) scene:createScene(event) end )
+scene:addEventListener( "hide", function(event) print("hide"); if event.phase == 'did' then scene:didExitScene(event) end end )
 
 return scene


### PR DESCRIPTION
This change set migrates from Storyboard api (removed) to the newer Composer api, and allows running the code on current Corona releases.

The lambda event listener wrappers aren't quite kosher, but that was the easies way to make all the test scenes work again.