### PR TITLE
Bypass the call to transition when scrollToIndex time is 0 - causes 1…

### DIFF
--- a/widgetLibrary/widget_tableview.lua
+++ b/widgetLibrary/widget_tableview.lua
@@ -1644,8 +1644,14 @@ local function createTableView( tableView, options )
 		-- If there is a transition underway, cancel it first
 		if self._transitionToIndex then transition.cancel( self._transitionToIndex ) end
 		-- Transition the view
-		self._transitionToIndex = transition.to( self, { y = newPosition, time = scrollTime, transition = easing.outQuad, onComplete = executeOnComplete } )
-
+		if scrollTime > 0 then
+			self._transitionToIndex = transition.to( self, { y = newPosition, time = scrollTime, transition = easing.outQuad, onComplete = executeOnComplete } )
+		else
+			self.y = newPosition
+			if executeOnComplete then
+				executeOnComplete()
+			end
+		end
 		-- Update the last row index
 		self._lastRowIndex = rowIndex
 	end


### PR DESCRIPTION
The call to transition.to causes a 1 frame delay. This causes a visual glitch when creating pickerwheels where columns have a startIndex other than 1. Pickerwheel uses tableviews for the individual columns. 

Where a pickerwheel needs to be rebuilt in response to user selection this becomes noticeable. For example a date pickerwheel where the day column values may need to change in response to month or year values.

widget v1 had this check. See e2d332fe8de858ed02150c37f878f1c7d2e1f529 for the change to always using transition and 4e2ed7f1f70eb4ab41e697ee5b9a5f61ff6fd768 for the previous version. As there is no comment on it, I assume it was done due to code simplification 